### PR TITLE
ability to use a pre-existing ipfs

### DIFF
--- a/dist/paratii.ipfs.js
+++ b/dist/paratii.ipfs.js
@@ -98,7 +98,15 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
     _this.config = config;
     _this.config.ipfs = result.value.ipfs;
     _this.config.account = result.value.account;
+    // TODO change this to some other name. this is wrong.
+    // because `this` isn't an ipfs instance.
     _this.config.ipfsInstance = _this;
+
+    // ability to use a pre-existing IPFS instance.
+    if (_this.config.ipfs && _this.config.ipfs.instance) {
+      _this.ipfs = _this.config.ipfs.instance;
+    }
+
     _this.local = new _paratiiIpfsLocal.ParatiiIPFSLocal(config);
     _this.remote = new _paratiiIpfsRemote.ParatiiIPFSRemote({ ipfs: _this.config.ipfs, paratiiIPFS: _this });
     _this.transcoder = new _paratiiTranscoder.ParatiiTranscoder({ ipfs: _this.config.ipfs, paratiiIPFS: _this });

--- a/dist/paratii.ipfs.js
+++ b/dist/paratii.ipfs.js
@@ -102,11 +102,6 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
     // because `this` isn't an ipfs instance.
     _this.config.ipfsInstance = _this;
 
-    // ability to use a pre-existing IPFS instance.
-    if (_this.config.ipfs && _this.config.ipfs.instance) {
-      _this.ipfs = _this.config.ipfs.instance;
-    }
-
     _this.local = new _paratiiIpfsLocal.ParatiiIPFSLocal(config);
     _this.remote = new _paratiiIpfsRemote.ParatiiIPFSRemote({ ipfs: _this.config.ipfs, paratiiIPFS: _this });
     _this.transcoder = new _paratiiTranscoder.ParatiiTranscoder({ ipfs: _this.config.ipfs, paratiiIPFS: _this });
@@ -309,27 +304,32 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
             return require('ipfs');
           }) // eslint-disable-line
           .then(function (Ipfs) {
-            var ipfs = new Ipfs({
-              bitswap: {
-                // maxMessageSize: 256 * 1024
-                maxMessageSize: _this5.config.ipfs['bitswap.maxMessageSize']
-              },
-              start: true,
-              repo: config.ipfs.repo || '/tmp/test-repo-' + String(Math.random()),
-              config: {
-                Addresses: {
-                  Swarm: _this5.config.ipfs.swarm
-                  // [
-                  //   '/dns4/star.paratii.video/tcp/443/wss/p2p-webrtc-star',
-                  //   '/dns4/ws.star.paratii.video/tcp/443/wss/p2p-websocket-star/'
-                  // ]
+            var ipfs = void 0;
+            if (_this5.config.ipfs.instance) {
+              ipfs = _this5.config.ipfs.instance;
+            } else {
+              ipfs = new Ipfs({
+                bitswap: {
+                  // maxMessageSize: 256 * 1024
+                  maxMessageSize: _this5.config.ipfs['bitswap.maxMessageSize']
                 },
-                Bootstrap: _this5.config.ipfs.bootstrap
-                // [
-                //   '/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'
-                // ]
-              }
-            });
+                start: true,
+                repo: config.ipfs.repo || '/tmp/test-repo-' + String(Math.random()),
+                config: {
+                  Addresses: {
+                    Swarm: _this5.config.ipfs.swarm
+                    // [
+                    //   '/dns4/star.paratii.video/tcp/443/wss/p2p-webrtc-star',
+                    //   '/dns4/ws.star.paratii.video/tcp/443/wss/p2p-websocket-star/'
+                    // ]
+                  },
+                  Bootstrap: _this5.config.ipfs.bootstrap
+                  // [
+                  //   '/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'
+                  // ]
+                }
+              });
+            }
 
             _this5.ipfs = ipfs;
 
@@ -349,22 +349,8 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
                 var peerInfo = id;
                 _this5.id = id;
                 _this5.log('[IPFS] id:  ' + peerInfo);
-                var ptiAddress = _this5.config.account.address || 'no_address';
-                _this5.protocol = new _paratiiProtocol2.default(ipfs._libp2pNode, ipfs._repo.blocks,
-                // add ETH Address here.
-                ptiAddress);
 
-                _this5._node = ipfs;
-                _this5.remote._node = ipfs;
-
-                _this5.protocol.notifications.on('message:new', function (peerId, msg) {
-                  _this5.log('[paratii-protocol] ', peerId.toB58String(), ' new Msg: ', msg);
-                });
-                // emit all commands.
-                // NOTE : this will be changed once protocol upgrades are ready.
-                _this5.protocol.notifications.on('command', function (peerId, command) {
-                  _this5.emit('protocol:incoming', peerId, command);
-                });
+                _this5.initProtocol(ipfs);
 
                 _this5.ipfs = ipfs;
                 _this5.protocol.start(function () {
@@ -384,6 +370,28 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
             });
           });
         }
+      });
+    }
+  }, {
+    key: 'initProtocol',
+    value: function initProtocol(ipfs) {
+      var _this6 = this;
+
+      var ptiAddress = this.config.account.address || 'no_address';
+      this.protocol = new _paratiiProtocol2.default(ipfs._libp2pNode, ipfs._repo.blocks,
+      // add ETH Address here.
+      ptiAddress);
+
+      this._node = ipfs;
+      this.remote._node = ipfs;
+
+      this.protocol.notifications.on('message:new', function (peerId, msg) {
+        _this6.log('[paratii-protocol] ', peerId.toB58String(), ' new Msg: ', msg);
+      });
+      // emit all commands.
+      // NOTE : this will be changed once protocol upgrades are ready.
+      this.protocol.notifications.on('command', function (peerId, command) {
+        _this6.emit('protocol:incoming', peerId, command);
       });
     }
   }]);

--- a/dist/schemas.js
+++ b/dist/schemas.js
@@ -40,6 +40,7 @@ var ethSchema = joi.object({
  * @property {Array=} swarm signaling server for finding ipfs nodes
  * @property {string=} transcoderDropUrl url for the express uploader
  * @property {number=} xhrChunkSize max chunk size for the express uploader
+ * @property {Ipfs=} instance a pre-existing IPFS instance.
  * @example {
  *   bitswap.maxMessageSize: 262144
  *   chunkSize : 131072
@@ -61,8 +62,8 @@ var ipfsSchema = joi.object({
   maxFileSize: joi.number().default(800 * 1024 * 1024),
   defaultTranscoder: joi.string().default('/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'),
   remoteIPFSNode: joi.string().default('/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'),
-  transcoderDropUrl: joi.string().default('https://uploader.paratii.video/api/v1/transcode')
-
+  transcoderDropUrl: joi.string().default('https://uploader.paratii.video/api/v1/transcode'),
+  instance: joi.any().default(null)
 }).default();
 
 /**

--- a/src/paratii.ipfs.js
+++ b/src/paratii.ipfs.js
@@ -36,7 +36,15 @@ export class ParatiiIPFS extends EventEmitter {
     this.config = config
     this.config.ipfs = result.value.ipfs
     this.config.account = result.value.account
+    // TODO change this to some other name. this is wrong.
+    // because `this` isn't an ipfs instance.
     this.config.ipfsInstance = this
+
+    // ability to use a pre-existing IPFS instance.
+    if (this.config.ipfs && this.config.ipfs.instance) {
+      this.ipfs = this.config.ipfs.instance
+    }
+
     this.local = new ParatiiIPFSLocal(config)
     this.remote = new ParatiiIPFSRemote({ipfs: this.config.ipfs, paratiiIPFS: this})
     this.transcoder = new ParatiiTranscoder({ipfs: this.config.ipfs, paratiiIPFS: this})

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -35,6 +35,7 @@ const ethSchema = joi.object({
  * @property {Array=} swarm signaling server for finding ipfs nodes
  * @property {string=} transcoderDropUrl url for the express uploader
  * @property {number=} xhrChunkSize max chunk size for the express uploader
+ * @property {Ipfs=} instance a pre-existing IPFS instance.
  * @example {
  *   bitswap.maxMessageSize: 262144
  *   chunkSize : 131072
@@ -65,8 +66,8 @@ const ipfsSchema = joi.object({
   maxFileSize: joi.number().default(800 * 1024 * 1024),
   defaultTranscoder: joi.string().default('/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'),
   remoteIPFSNode: joi.string().default('/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'),
-  transcoderDropUrl: joi.string().default('https://uploader.paratii.video/api/v1/transcode')
-
+  transcoderDropUrl: joi.string().default('https://uploader.paratii.video/api/v1/transcode'),
+  instance: joi.any().default(null)
 }).default()
 
 /**

--- a/test/paratii.ipfs.js
+++ b/test/paratii.ipfs.js
@@ -1,6 +1,7 @@
 import Paratii from '../src/paratii.js'
 import { ParatiiIPFS } from '../src/paratii.ipfs.js'
 import { assert, expect } from 'chai'
+import Ipfs from 'ipfs'
 
 describe('ParatiiIPFS: :', function () {
   let paratiiIPFS
@@ -74,5 +75,20 @@ describe('ParatiiIPFS: :', function () {
     let paratii = await new Paratii()
     let result = await paratii.ipfs.addAndPinJSON({test: 1})
     assert.isOk(result)
+  })
+
+  it('should be able to use a pre-existing ipfs instance', async function () {
+    let repoPath = '/tmp/pre-existing-ipfs'
+    let existingIPFS = new ParatiiIPFS({
+      ipfs: {
+        instance: new Ipfs({
+          repo: repoPath
+        })
+      }
+    })
+
+    assert.isOk(existingIPFS)
+    assert.isOk(existingIPFS.ipfs)
+    assert.equal(existingIPFS.ipfs._repo.path, repoPath)
   })
 })

--- a/test/paratii.ipfs.js
+++ b/test/paratii.ipfs.js
@@ -79,15 +79,21 @@ describe('ParatiiIPFS: :', function () {
 
   it('should be able to use a pre-existing ipfs instance', async function () {
     let repoPath = '/tmp/pre-existing-ipfs'
+    let ipfs = new Ipfs({
+      bitswap: {
+        maxMessageSize: 256 * 1024
+      },
+      repo: repoPath,
+      start: true
+    })
     let existingIPFS = new ParatiiIPFS({
       ipfs: {
-        instance: new Ipfs({
-          repo: repoPath
-        })
+        instance: ipfs
       }
     })
 
     assert.isOk(existingIPFS)
+    await existingIPFS.getIPFSInstance()
     assert.isOk(existingIPFS.ipfs)
     assert.equal(existingIPFS.ipfs._repo.path, repoPath)
   })


### PR DESCRIPTION
allows `paratiiIPFS` to use a pre-existing `IPFS` instance. useful in case the browser already has ipfs running in the background.