### PR TITLE
#277 return tx and salt used

### DIFF
--- a/src/paratii.eth.tcr.js
+++ b/src/paratii.eth.tcr.js
@@ -413,7 +413,7 @@ export class ParatiiEthTcr {
    * @param  {string}  videoId     univocal video identifier
    * @param  {integer}  vote        1 vote for, 0 vote against
    * @param  {number}  amountInWei amount for the vote
-   * @return {Promise}             commit tx
+   * @return {Promise}             commit tx, salt
    * @example let tx = await paratii.eth.tcr.approveAndGetRightsAndCommitVote('some-video-id',1,paratii.eth.web3.utils.toWei('5'))
    */
   async approveAndGetRightsAndCommitVote (videoId, vote, amountInWei) {
@@ -432,9 +432,12 @@ export class ParatiiEthTcr {
     let tx = await this.requestVotingRights(amountInWei)
     if (!tx.events._VotingRightsGranted) { throw new Error('Rights request failed') }
 
-    let commitVoteTx = await this.commitVote(videoId, vote, amountInWei)
-    console.log(commitVoteTx)
-    return commitVoteTx
+    let results = await this.commitVote(videoId, vote, amountInWei)
+    // let commitVoteTx = results.tx
+    // let salt = results.salt
+    // console.log('commitVoteTx', commitVoteTx)
+    // console.log('salt', salt)
+    return results
   }
   /**
    * Commits vote using hash of choice and secret salt to conceal vote until reveal
@@ -495,7 +498,7 @@ export class ParatiiEthTcr {
       prevNode
     ).send()
 
-    return tx
+    return { tx, salt }
   }
 
   /**

--- a/test/1.paratii.eth.tcr.js
+++ b/test/1.paratii.eth.tcr.js
@@ -543,9 +543,10 @@ describe('paratii.eth.tcr:', function () {
     assert.isTrue(isCommitPeriodActive)
 
     // one vote for
-    let commitVoteTx = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, vote, paratii.eth.web3.utils.toWei('1'))
-    assert.isOk(commitVoteTx)
-    assert.isOk(commitVoteTx.events._VoteCommitted)
+    let { tx, salt } = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, vote, paratii.eth.web3.utils.toWei('1'))
+    assert.isOk(tx)
+    assert.isOk(salt)
+    assert.isOk(tx.events._VoteCommitted)
 
     let hasVotingRights = await paratii.eth.tcr.hasVotingRights(paratii.eth.web3.utils.toWei('1'))
     assert.isTrue(hasVotingRights)
@@ -744,9 +745,10 @@ describe('paratii.eth.tcr:', function () {
 
     let balanceBeforeVoting = new BigNumber(await paratii.eth.balanceOf(paratii.eth.getAccount(), 'PTI'))
 
-    let commitVoteTx = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, 1, 1)
-    assert.isOk(commitVoteTx)
-    assert.isOk(commitVoteTx.events._VoteCommitted)
+    let commitVoteResult = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, 1, 1)
+    assert.isOk(commitVoteResult.tx)
+    assert.isOk(commitVoteResult.salt)
+    assert.isOk(commitVoteResult.tx.events._VoteCommitted)
 
     let didCommit = await paratii.eth.tcr.didCommit(paratii.eth.getAccount(), challengeID)
     assert.isTrue(didCommit)
@@ -803,9 +805,10 @@ describe('paratii.eth.tcr:', function () {
 
     let challengeID = await challengeFromDifferentAccount(myPrivateKey, id, 10, paratii)
 
-    let commitVoteTx = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, 1, paratii.eth.web3.utils.toWei('3'))
-    assert.isOk(commitVoteTx)
-    assert.isOk(commitVoteTx.events._VoteCommitted)
+    let commitVoteResult = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, 1, paratii.eth.web3.utils.toWei('3'))
+    assert.isOk(commitVoteResult.tx)
+    assert.isOk(commitVoteResult.salt)
+    assert.isOk(commitVoteResult.tx.events._VoteCommitted)
 
     let numTokens = await paratii.eth.tcr.getNumTokens(paratii.eth.getAccount(), challengeID)
     assert.equal(numTokens, paratii.eth.web3.utils.toWei('3'))


### PR DESCRIPTION
small edit to return `salt` along with the transaction when `approveAndGetRightsAndCommitVote` is called. 

```javascript
 let commitVoteResult = await paratii.eth.tcr.approveAndGetRightsAndCommitVote(id, 1, 1)
 assert.isOk(commitVoteResult.tx)
 assert.isOk(commitVoteResult.salt)
 assert.isOk(commitVoteResult.tx.events._VoteCommitted)
```